### PR TITLE
Correct DockerHub org name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,4 @@ jobs:
         with:
           push: true
           tags: "${{ env.tag }}"
+        if: github.event_name != 'pull_request'


### PR DESCRIPTION
Should be `shillakerscw`, not `shillaker`.

The use of this org is temporary, and will eventually become `scaleway`, but we can test and get things working on this org first.