### PR TITLE
Build and push image to SCW registry.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           push: true
           tags: "${{ env.tag }}"
-        #if: github.event_name != 'pull_request' 
+        if: github.event_name != 'pull_request'


### PR DESCRIPTION
The changes allow to build and push docker image to a scaleway registry in github actions. The used registry is set up under "scw-serverless" namespace and has public access policy for image pulling.