### PR TITLE
Export gateway url/token as env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,14 @@ check-container:
 	region=${SCW_API_REGION}
 
 #--------------------------
+# Container endpoint export
+#--------------------------
+.PHONY: get-gateway-endpoint
+get-gateway-endpoint:
+	$(eval $(call container_id,_id))
+	@echo $(shell scw container container get ${_id} region=${SCW_API_REGION} -o json | jq -r '.domain_name')
+
+#--------------------------
 # S3
 #--------------------------
 .PHONY: set-up-s3-cli
@@ -187,6 +195,10 @@ delete-bucket:
 .PHONY: list-tokens
 list-tokens:
 	@s3cmd ls s3://${S3_BUCKET_NAME} | awk -F'/' '{print$$4}'
+
+.PHONY: get-token
+get-token:
+	@echo $(shell make list-tokens) | awk '{print$$1}'
 
 #--------------------------
 # Tests

--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ export GATEWAY_TOKEN=$(make get-gateway-token)
 ### Add a function as a target in your gateway
 You can add `hello` function to the deployed gateway using:
 ```
-curl -X POST http://<your container domain name>/scw \
+export GATEWAY_URL=$(make get-gateway-endpoint)
+export GATEWAY_TOKEN=$(make get-gateway-token)
+
+curl -X POST ${GATEWAY_URL}/scw \
              -H 'X-Auth-Token: ${GATEWAY_TOKEN}' \
              -H 'Content-Type: application/json' \
              -d '{"target":"<your hello function URL>","relative_url":"/hello"}'

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export GATEWAY_TOKEN=$(make get-gateway-token)
 You can add `hello` function to the deployed gateway using:
 ```
 curl -X POST http://<your container domain name>/scw \
-             -H 'X-Auth-Token: <generated_key>' \
+             -H 'X-Auth-Token: ${GATEWAY_TOKEN}' \
              -H 'Content-Type: application/json' \
              -d '{"target":"<your hello function URL>","relative_url":"/hello"}'
 ```

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ make update-container
 ### Add gateway URL as environment variable
 You can use:
 ```
-export GATEWAY_URL=$(make get-gateway-token)
+export GATEWAY_URL=$(make get-gateway-endpoint)
 ```
 
 ### Deploy your function

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You will get two URLs, one for `hello` function and the other one for `goodbye` 
 
 ### Generate a token
 ```
-curl -X POST http://<your container domain name>/token
+curl -X POST http://${GATEWAY_URL}/token
 ```
 The generated key will be uploaded to your bucket.
 
@@ -114,11 +114,8 @@ export GATEWAY_TOKEN=$(make get-gateway-token)
 ### Add a function as a target in your gateway
 You can add `hello` function to the deployed gateway using:
 ```
-export GATEWAY_URL=$(make get-gateway-endpoint)
-export GATEWAY_TOKEN=$(make get-gateway-token)
-
-curl -X POST ${GATEWAY_URL}/scw \
-             -H 'X-Auth-Token: ${GATEWAY_TOKEN}' \
+curl -X POST http://${GATEWAY_URL}/scw \
+             -H "X-Auth-Token: ${GATEWAY_TOKEN}" \
              -H 'Content-Type: application/json' \
              -d '{"target":"<your hello function URL>","relative_url":"/hello"}'
 ```
@@ -126,19 +123,19 @@ You can add as many endpoints as you want to your serverless gateway.
 
 ### List the endpoints of your gateway
 ```
-curl http://<your container domain name>/scw -H 'X-Auth-Token: <generated_key>' | jq
+curl http://${GATEWAY_URL}/scw -H "X-Auth-Token: ${GATEWAY_TOKEN}"| jq
 ```
 
 ### Call your function using gateway base URL
 ```
-curl http://<your container domain name>/hello
+curl http://${GATEWAY_URL}/hello
 ```
 
 ### Delete a target in your gateway
 You can remove `hello` function as a target from your gateway using:
 ```
-curl -X DELETE http://<your container domain name>/scw \
-               -H 'X-Auth-Token: <generated_key>' \
+curl -X DELETE http://${GATEWAY_URL}/scw \
+               -H "X-Auth-Token: ${GATEWAY_TOKEN}" \
                -H 'Content-Type: application/json' \
                -d '{"target":"<your hello function URL>,"relative_url":"/hello"}'
 ```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ In case you want to update your container, you can use:
 make update-container
 ```
 
+### Add gateway URL as environment variable
+You can use:
+```
+export GATEWAY_URL=$(make get-gateway-token)
+```
+
 ### Deploy your function
 You can use the functions in the handler at `endpoints/func-example` and deploy it using Scaleway's Serverless API framework using:
 ```
@@ -99,10 +105,17 @@ You will need this token to authenticate against all `/scw` calls
 make list-tokens
 ```
 
+### Add token as environment variable
+You can use:
+```
+export GATEWAY_TOKEN=$(make get-gateway-token)
+```
+
 ### Add a function as a target in your gateway
 You can add `hello` function to the deployed gateway using:
 ```
 curl -X POST http://<your container domain name>/scw \
+             -H 'X-Auth-Token: <generated_key>' \
              -H 'Content-Type: application/json' \
              -d '{"target":"<your hello function URL>","relative_url":"/hello"}'
 ```


### PR DESCRIPTION
## Summary

**_What's changed?_**
This add commands to make in order to get gateway's base url and a valid token. The readme instruct users to export these them into environment variables.
 
**_Why do we need this?_**
Ease user experience and demoing.

## Checklist

- [x] I have reviewed this myself
- [x] I have updated the relevant documentation
