### PR TITLE
feat: add password generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,34 @@
 
 The Scaleway Serverless Gateway is a self-hosted API gateway that runs on Scaleway [Serverless Containers](https://www.scaleway.com/en/serverless-containers/).
 
-It lets you manage routing from a single base URL, as well as handling transversal concerns such as CORS and authentication.
+It lets you manage routing from a single base URL, as well as handle transversal concerns such as CORS and authentication.
 
-It is built on [Kong Gateway](https://docs.konghq.com/gateway/latest/), giving you access to the [Kong plugin ecosystem](https://docs.konghq.com/hub/) to customise your own deployments.
+It is built on [Kong Gateway](https://docs.konghq.com/gateway/latest/), giving you access to the [Kong plugin ecosystem](https://docs.konghq.com/hub/) to customize your own deployments.
 
 ## :page_with_curl: Summary
 
-- [Features](#rocket-features)
-- [Quick-start](#computer-quick-start)
-- [Custom domains](#custom-domains)
-- [Serverless functions](#serverless-functions)
-- [Architecture](#hammer-architecture)
-- [Contributing](#mortar_board-contributing)
-- [Reach Us](#mailbox-reach-us)
+- [Scaleway Serverless Gateway :door:](#scaleway-serverless-gateway-door)
+  - [:page\_with\_curl: Summary](#page_with_curl-summary)
+  - [:rocket: Features](#rocket-features)
+  - [:computer: Quick-start](#computer-quick-start)
+    - [Updating your gateway](#updating-your-gateway)
+    - [Deleting your gateway](#deleting-your-gateway)
+  - [Custom domains](#custom-domains)
+  - [Serverless functions](#serverless-functions)
+  - [:hammer: Architecture](#hammer-architecture)
+    - [Authentication](#authentication)
+    - [Configuring routes](#configuring-routes)
+  - [:mortar\_board: Contributing](#mortar_board-contributing)
+  - [:mailbox: Reach Us](#mailbox-reach-us)
 
 ## :rocket: Features
 
 The Serverless Gateway:
 
-* Adds routing via a single base URL
-* Adds routing based on HTTP methods
-* Adds permissive CORS by default, to support accessing routes from a browser
-* Gives access to a serverless [Kong Gateway](https://docs.konghq.com/gateway/latest/) deployment
+- Adds routing via a single base URL
+- Adds routing based on HTTP methods
+- Adds permissive CORS by default, to support accessing routes from a browser
+- Gives access to a serverless [Kong Gateway](https://docs.konghq.com/gateway/latest/) deployment
 
 The Serverless Gateway integrates fully with the [Scaleway Python API framework](https://github.com/scaleway/serverless-api-project), which makes building and managing complex serverless APIs easy.
 
@@ -31,7 +37,7 @@ The Serverless Gateway integrates fully with the [Scaleway Python API framework]
 
 To deploy your gateway you need to install and configure the [Scaleway CLI](https://github.com/scaleway/scaleway-cli), and the [Gateway CLI](https://pypi.org/project/scw-gateway/) via [`pip`](https://pip.pypa.io/en/stable/index.html):
 
-```
+```console
 pip install scw-gateway
 ```
 
@@ -43,7 +49,7 @@ The gateway image itself is packaged via our public [Serverless Gateway Docker i
 
 To deploy your gateway, you need to create a container namespace, and a container in that namespace using the public gateway image:
 
-```
+```console
 # Create the database
 scwgw create-db
 
@@ -67,7 +73,7 @@ scwgw await-db
 
 Configure your local CLI to use all the newly deployed resources:
 
-```
+```console
 scwgw remote-config
 ```
 
@@ -75,7 +81,7 @@ scwgw remote-config
 
 You can add a route to any URL, here we will use the `worldtimeapi`.
 
-```
+```console
 # Curl the URL directly
 curl http://worldtimeapi.org/api/timezone/Europe/Paris
 
@@ -90,7 +96,7 @@ curl http://${GATEWAY_HOST}/time
 
 You can list the routes configured on your gateway with:
 
-```
+```console
 scwgw get-routes
 ```
 
@@ -98,7 +104,7 @@ scwgw get-routes
 
 If you make changes to your gateway in this repo, you can run the following to update it:
 
-```
+```console
 # Update without redeploy
 scwgw update-container-no-redeploy
 
@@ -110,7 +116,7 @@ scwgw update-container
 
 To clear up everything related to your gateway, you can run:
 
-```
+```console
 # Delete the namespace, which implicitly deletes the container
 scwgw delete-namespace
 
@@ -124,15 +130,15 @@ You can add a custom domain to your gateway as with any other Serverless Contain
 
 You can register a new domain as described in the [Domains and DNS docs](https://www.scaleway.com/en/docs/network/domains-and-dns/quickstart/).
 
-Then you can add your domain name as global variable to the makefile:
+Then you can add your domain name as a global variable to the makefile:
 
-```
+```console
 GATEWAY_CUSTOM_DOMAIN := your-custom-domain-name
 ```
 
-Then uou can add your domain name to your gateway using:
+Then you can add your domain name to your gateway using:
 
-```
+```console
 scwgw set-custom-domain
 ```
 
@@ -146,7 +152,7 @@ This function uses [Scaleway's Python Serverless API Framework](https://github.c
 
 Once set up, you can deploy the functions with:
 
-```
+```console
 scw-serverless deploy endpoints/func-example/handler.py
 ```
 
@@ -172,7 +178,7 @@ The generated tokens are uploaded to a private bucket configured using the param
 
 The `/scw` endpoint allows us to add and remove routes without having to redeploy the gateway and interrupt service.
 
-Routes has the following fields:
+Routes have the following fields:
 
 - `relative_url`: the relative URL on the gateway.
 - `target_url`: the URL of the target function or container.

--- a/cli/cli/client.py
+++ b/cli/cli/client.py
@@ -1,0 +1,12 @@
+from scaleway import Client
+from scaleway_core.bridge import region
+
+DEFAULT_API_REGION = region.REGION_FR_PAR
+
+
+def get_scaleway_client() -> Client:
+    """Create a Scaleway client."""
+    scw_client = Client.from_config_file_and_env()
+    if not scw_client.default_region:
+        scw_client.default_region = DEFAULT_API_REGION
+    return scw_client

--- a/cli/cli/conf.py
+++ b/cli/cli/conf.py
@@ -1,4 +1,82 @@
 import os
+import typing as t
+from dataclasses import asdict, dataclass
+
+import yaml
+
+if t.TYPE_CHECKING:
+    # Importing conditionally to avoid circular imports
+    from cli.infra import InfraManager
 
 USER_HOME = os.path.expanduser("~")
 CONFIG_FILE = os.path.join(USER_HOME, ".config", "scw", "gateway.yml")
+
+# Name is fixed for Scaleway managed database
+DB_DATABASE_NAME = "rdb"
+DB_DATABASE_NAME_LOCAL = "kong"
+
+
+@dataclass
+class InfraConfiguration:
+    """Configuration used to store information of a deployed gateway."""
+
+    protocol: t.Literal["http", "https"]
+    gw_admin_host: str
+    gw_admin_port: str
+    gw_admin_token: str
+    gw_host: str
+    gw_port: str
+    db_host: str
+    db_port: str
+    db_name: str
+
+    @staticmethod
+    def from_local() -> "InfraConfiguration":
+        """Get the configuration for the local docker-compose stack."""
+        return InfraConfiguration(
+            protocol="http",
+            gw_admin_host="localhost",
+            gw_admin_port="8001",
+            gw_admin_token="",
+            gw_host="localhost",
+            gw_port="8080",
+            db_host="localhost",
+            db_port="5432",
+            db_name=DB_DATABASE_NAME_LOCAL,
+        )
+
+    @staticmethod
+    def from_infra(manager: "InfraManager") -> "InfraConfiguration":
+        admin_host = manager.get_gateway_admin_endpoint()
+        container_host = manager.get_gateway_endpoint()
+
+        instance = manager._get_database_instance()
+        if not instance:
+            raise RuntimeError("Could not finda database instance")
+        endpoint = instance.endpoints[0]
+
+        token = manager.create_admin_container_token()
+
+        return InfraConfiguration(
+            protocol="https",
+            gw_admin_host=admin_host,
+            gw_admin_port="",
+            gw_admin_token=token,
+            gw_host=container_host,
+            gw_port="",
+            db_host=str(endpoint.ip),
+            db_port=str(endpoint.port),
+            db_name=DB_DATABASE_NAME,
+        )
+
+    @staticmethod
+    def load() -> "InfraConfiguration":
+        """Read the configuration from the config file."""
+        with open(CONFIG_FILE, mode="rt", encoding="utf-8") as file:
+            conf = yaml.safe_load(file)
+            return InfraConfiguration(**conf)
+
+    def save(self) -> None:
+        """Save the configuration to a file."""
+        with open(CONFIG_FILE, mode="wt", encoding="utf-8") as file:
+            yaml.safe_dump(asdict(self), file)

--- a/cli/cli/credentials.py
+++ b/cli/cli/credentials.py
@@ -1,0 +1,87 @@
+import base64
+import secrets
+import string
+import zlib
+
+import click
+import scaleway.secret.v1alpha1 as sm
+from loguru import logger
+from scaleway import Client, ScalewayException
+
+# Name of the secret in Scaleway Secret Manager
+PASSWORD_NAME = "scw-gw-database-password"
+PASSWORD_LENGTH = 32
+
+
+def generate_database_password() -> str:
+    """Generate a random password for the database.
+
+    Made to be compatible with the requirements of Scaleway Database.
+    """
+    for _ in range(100):
+        password = "".join(
+            secrets.choice(string.ascii_letters + string.digits + string.punctuation)
+            for _ in range(PASSWORD_LENGTH)
+        )
+        if (
+            any(c.islower() for c in password)
+            and any(c.isupper() for c in password)
+            and any(c.isdigit() for c in password)
+            and any(c in string.punctuation for c in password)
+        ):
+            return password
+    raise RuntimeError("Could not generate a password")
+
+
+def store_db_password_to_scaleway_secret(scw_client: Client, db_password: str):
+    """Store the password to Scaleway Secret Manager."""
+    api = sm.SecretV1Alpha1API(scw_client)
+    try:
+        secret = api.get_secret_by_name(secret_name=PASSWORD_NAME)
+        raise RuntimeError(f"Secret {PASSWORD_NAME} already exists with id {secret.id}")
+    except ScalewayException as exception:
+        if exception.status_code != 404:
+            raise exception
+
+    logger.info("Creating secret for database password")
+    secret = api.create_secret(
+        name=PASSWORD_NAME,
+        tags=["scw-gw"],
+        description="Password for the database for scw-gw",
+    )
+
+    data = db_password.encode("utf-8")
+    api.create_secret_version(
+        secret_id=secret.id,
+        data=base64.b64encode(data).decode("utf-8"),
+        data_crc32=zlib.crc32(data) & 0xFFFFFFFF,
+    )
+
+
+def get_db_password_from_scaleway_secret(scw_client: Client) -> str:
+    """Get the password from Scaleway Secret Manager."""
+    api = sm.SecretV1Alpha1API(scw_client)
+    version = api.access_secret_version_by_name(
+        secret_name=PASSWORD_NAME, revision="latest"
+    )
+    password = base64.b64decode(version.data)
+    data_crc32 = zlib.crc32(password) & 0xFFFFFFFF
+    if version.data_crc32 and not secrets.compare_digest(
+        str(data_crc32), str(version.data_crc32)
+    ):
+        raise ValueError("CRC32 of data does not match")
+    return password.decode("utf-8")
+
+
+def load_db_password_or_abort(scw_client: Client) -> str:
+    """Load the password from Scaleway Secret Manager or abort."""
+    logger.debug("Looking for database password in Scaleway Secret Manager")
+    try:
+        password = get_db_password_from_scaleway_secret(scw_client)
+        return password
+    except ScalewayException as exception:
+        if exception.status_code == 404:
+            click.secho(
+                "Database password not found in Scaleway Secret Manager", fg="red"
+            )
+        raise exception

--- a/cli/cli/gateway.py
+++ b/cli/cli/gateway.py
@@ -1,36 +1,43 @@
 import requests
-import yaml
 from loguru import logger
 
-from cli.conf import CONFIG_FILE
+from cli import conf
 from cli.model import Route
 
 
-class GatewayManager(object):
+def response_hook(response: requests.Response, *_args, **_kwargs):
+    """Response hook to log request and call raise_for_status."""
+    req = response.request
+    logger.debug(f"{req.method}: {req.url}")
+    response.raise_for_status()
+
+
+class GatewayManager:
+    """Configure routes via the Kong admin API."""
+
     def __init__(self):
         # Local local config
-        with open(CONFIG_FILE, "r") as fh:
-            self.config = yaml.safe_load(fh)
+        self.config = conf.InfraConfiguration.load()
 
         self.admin_url = [
-            self.config["protocol"],
+            self.config.protocol,
             "://",
-            self.config["gw_admin_host"],
+            self.config.gw_admin_host,
         ]
 
-        admin_port = self.config.get("gw_admin_port")
+        admin_port = self.config.gw_admin_port
         if admin_port:
             self.admin_url.extend([":", str(admin_port)])
 
         self.admin_url = "".join(self.admin_url)
 
         self.gateway_url = [
-            self.config["protocol"],
+            self.config.protocol,
             "://",
-            self.config["gw_host"],
+            self.config.gw_host,
         ]
 
-        gateway_port = self.config.get("gw_port")
+        gateway_port = self.config.gw_port
         if gateway_port:
             self.gateway_url.extend([":", str(gateway_port)])
 
@@ -38,24 +45,24 @@ class GatewayManager(object):
 
         self.routes_url = self.admin_url + "/routes"
         self.services_url = self.admin_url + "/services"
-        self.token = self.config.get("gw_admin_token")
+        self.token = self.config.gw_admin_token
 
-        self.auth_headers = dict()
-        if self.token:
-            self.auth_headers["X-Auth-Token"] = self.token
+        self.session = requests.Session()
+        self.session.headers["X-Auth-Token"] = self.token
+        self.session.hooks["response"].append(response_hook)
 
     def add_route(self, route: Route):
         service_url = f"{self.services_url}/{route.name}"
         route_url = f"{self.routes_url}/{route.name}"
 
-        self._do_request("PUT", service_url, data=route.service_json())
-        resp = self._do_request("PUT", route_url, data=route.route_json())
+        self.session.put(url=service_url, data=route.service_json())
+        resp = self.session.put(url=route_url, data=route.route_json())
 
         if route.cors:
             plugins_url = f"{route_url}/plugins"
 
             try:
-                self._do_request("POST", plugins_url, data=route.cors_json())
+                self.session.post(url=plugins_url, data=route.cors_json())
             except requests.HTTPError:
                 # TODO - avoid ignoring this, any way to create or update?
                 pass
@@ -63,50 +70,32 @@ class GatewayManager(object):
         return resp
 
     def delete_route(self, route: Route):
-        self._do_request("DELETE", f"{self.routes_url}/{route.name}")
-        resp = self._do_request("DELETE", f"{self.services_url}/{route.name}")
+        self.session.delete(url=f"{self.routes_url}/{route.name}")
+        resp = self.session.delete(url=f"{self.services_url}/{route.name}")
         return resp
 
     def get_routes(self):
-        resp = self._do_request("GET", self.routes_url)
+        resp = self.session.get(url=self.routes_url)
         route_data = {r.get("name"): r for r in resp.json().get("data")}
 
-        resp = self._do_request("GET", self.services_url)
+        resp = self.session.get(url=self.services_url)
         service_data = {s.get("name"): s for s in resp.json().get("data")}
 
         routes = list()
         for _, r in route_data.items():
-            name = r["name"]
-            relative_url = r["paths"][0]
+            route_name = r["name"]
+            route_paths = r["paths"]
             http_methods = r.get("methods")
 
-            s = service_data.get(name)
-            port = s["port"]
-            host = s["host"]
-            protocol = s["protocol"]
-            url = f"{protocol}://{host}:{port}"
+            service = service_data.get(route_name)
+            if not service:
+                continue
 
-            routes.append(Route(relative_url, url, http_methods=http_methods))
+            service_port = service["port"]
+            service_host = service["host"]
+            service_protocol = service["protocol"]
+            service_url = f"{service_protocol}://{service_host}:{service_port}"
+
+            routes.append(Route(route_paths, service_url, http_methods=http_methods))
 
         return routes
-
-    def _do_request(self, method, url, data=None) -> requests.Response:
-        logger.debug(f"{method}: {url}")
-
-        if method == "GET":
-            resp = requests.get(url, headers=self.auth_headers)
-        elif method == "DELETE":
-            resp = requests.delete(url, headers=self.auth_headers)
-        elif method == "PATCH":
-            resp = requests.patch(url, headers=self.auth_headers, json=data)
-        elif method == "POST":
-            resp = requests.post(url, headers=self.auth_headers, json=data)
-        elif method == "PUT":
-            resp = requests.put(url, headers=self.auth_headers, json=data)
-        else:
-            logger.error(f"Invalid method: {method}")
-            raise RuntimeError("Invalid HTTP method")
-
-        resp.raise_for_status()
-
-        return resp

--- a/cli/cli/infra.py
+++ b/cli/cli/infra.py
@@ -1,28 +1,13 @@
 import copy
-import time
+from concurrent import futures
 
 import click
-import yaml
+import scaleway.container.v1beta1 as cnt
+import scaleway.function.v1beta1 as fnc
+import scaleway.rdb.v1 as rdb
 from scaleway import Client
-from scaleway.container.v1beta1 import (
-    Container,
-    ContainerHttpOption,
-    ContainerPrivacy,
-    ContainerProtocol,
-    ContainerStatus,
-    ContainerV1Beta1API,
-    ListContainersResponse,
-    ListNamespacesResponse,
-    Namespace,
-    NamespaceStatus,
-    Token,
-)
-from scaleway.function.v1beta1 import FunctionV1Beta1API, ListFunctionsResponse
-from scaleway.rdb.v1 import Instance, InstanceStatus, ListInstancesResponse, RdbV1API
 
-from cli.conf import CONFIG_FILE
-
-API_REGION = "fr-par"
+from cli import conf
 
 AWAIT_DELAY_SECONDS = 5
 AWAIT_RETRIES = 60
@@ -52,107 +37,80 @@ CONTAINER_ADMIN_MEMORY_LIMIT = 1024
 DB_INSTANCE_NAME = "scw-sls-gw"
 DB_ENGINE = "PostgreSQL-14"
 DB_USERNAME = "kong"
-DB_PASSWORD = "K0ngkongkong!"
 DB_VOLUME_TYPE = "lssd"
 DB_NODE_TYPE = "DB-DEV-S"
-DB_VOLUME_SIZE = "5000000000"  # Expressed in bytes
+DB_VOLUME_SIZE = 5000000000  # Expressed in bytes
 
 # Name is fixed for Scaleway managed database
 DB_DATABASE_NAME = "rdb"
-DB_DATABASE_NAME_LOCAL = "kong"
 
 
-class InfraManager(object):
-    def __init__(self):
+class InfraManager:
+    """Manager for the infrastructure of the gateway."""
+
+    def __init__(self, scw_client: Client):
         # Initialise SCW client
-        self.scw_client = Client.from_config_file_and_env()
+        self.scw_client = scw_client
 
         # Init Scaleway APIs
-        self.containers = ContainerV1Beta1API(self.scw_client)
-        self.functions = FunctionV1Beta1API(self.scw_client)
-        self.rdb = RdbV1API(self.scw_client)
+        self.containers = cnt.ContainerV1Beta1API(self.scw_client)
+        self.functions = fnc.FunctionV1Beta1API(self.scw_client)
+        self.rdb = rdb.RdbV1API(self.scw_client)
 
-    def set_up_config(self, is_local: bool):
+    def set_up_config(self, is_local: bool) -> None:
+        """Set up the configuration for the gateway.
+
+        Used by the GatewayManager to set up the route configuration.
+        """
         if is_local:
-            config_data = {
-                "protocol": "http",
-                "gw_admin_host": "localhost",
-                "gw_admin_port": "8001",
-                "gw_admin_token": "",
-                "gw_host": "localhost",
-                "gw_port": "8080",
-                "db_host": "localhost",
-                "db_port": "5432",
-                "db_name": DB_DATABASE_NAME_LOCAL,
-            }
+            config = conf.InfraConfiguration.from_local()
         else:
-            admin_host = self.get_gateway_admin_endpoint()
-            container_host = self.get_gateway_endpoint()
+            config = conf.InfraConfiguration.from_infra(self)
+        config.save()
 
-            instance = self._get_database_instance()
-            if not instance:
-                click.secho("No database instance found", fg="red", bold=True)
-                raise click.Abort()
-
-            token = self.create_admin_container_token()
-
-            config_data = {
-                "protocol": "https",
-                "gw_admin_host": admin_host,
-                "gw_admin_port": "",
-                "gw_admin_token": token,
-                "gw_host": container_host,
-                "gw_port": "",
-                "db_host": instance.endpoint.ip,
-                "db_port": instance.endpoint.port,
-                "db_name": DB_DATABASE_NAME,
-            }
-
-        with open(CONFIG_FILE, "w") as fh:
-            yaml.safe_dump(config_data, fh)
-
-    def _do_await(self, check_func):
-        for r in range(AWAIT_RETRIES):
-            if check_func():
-                break
-
-            click.secho(".", nl=False)
-
-            time.sleep(AWAIT_DELAY_SECONDS)
-
-    def _get_container(self, admin=False):
+    def _get_container(self, admin=False) -> cnt.Container | None:
         namespace = self._get_namespace()
         if not namespace:
             click.secho("No namespace found", fg="red", bold=True)
             raise click.Abort()
 
         container_name = CONTAINER_ADMIN_NAME if admin else CONTAINER_NAME
-        containers: ListContainersResponse = self.containers.list_containers_all(
+        containers = self.containers.list_containers_all(
             namespace_id=namespace.id,
-            region=API_REGION,
             name=container_name,
         )
 
         return containers[0] if containers else None
 
-    def _get_admin_container(self):
+    def _get_admin_container(self) -> cnt.Container | None:
         return self._get_container(admin=True)
 
-    def _get_database_instance(self):
-        instances: ListInstancesResponse = self.rdb.list_instances_all(
-            region=API_REGION, name=DB_INSTANCE_NAME
-        )
+    def _get_container_or_abort(self, admin: bool = False) -> cnt.Container:
+        container = self._get_container()
+        if not container:
+            container_name = "Admin" if admin else "Gateway"
+            click.secho(
+                f"{container_name} container not found"
+                "Run `scw-gw create-containers` to deploy the gateway",
+                fg="red",
+                bold=True,
+            )
+            raise click.Abort()
+        return container
+
+    def _get_admin_container_or_abort(self) -> cnt.Container:
+        return self._get_container_or_abort(admin=True)
+
+    def _get_database_instance(self) -> rdb.Instance | None:
+        instances = self.rdb.list_instances_all(name=DB_INSTANCE_NAME)
         return instances[0] if instances else None
 
     def _get_namespace(self):
-        namespaces: ListNamespacesResponse = self.containers.list_namespaces_all(
-            region=API_REGION, name=CONTAINER_NAMESPACE
-        )
+        namespaces = self.containers.list_namespaces_all(name=CONTAINER_NAMESPACE)
         return namespaces[0] if namespaces else None
 
-    def get_function_endpoint(self, namespace_name, function_name):
+    def get_function_endpoint(self, namespace_name, function_name) -> str | None:
         namespaces = self.functions.list_namespaces_all(
-            region=API_REGION,
             name=namespace_name,
         )
         if not namespaces:
@@ -160,31 +118,21 @@ class InfraManager(object):
             raise click.Abort()
 
         namespace = namespaces[0]
-        functions: ListFunctionsResponse = self.functions.list_functions_all(
-            namespace_id=namespace.id, region=API_REGION
+        functions = self.functions.list_functions_all(
+            namespace_id=namespace.id, name=function_name
         )
 
         return functions[0].domain_name if functions else None
 
-    def get_gateway_endpoint(self):
-        container = self._get_container()
-
-        if not container:
-            click.secho("No admin container found", fg="red", bold=True)
-            raise click.Abort()
-
+    def get_gateway_endpoint(self) -> str:
+        container = self._get_container_or_abort()
         return container.domain_name
 
-    def get_gateway_admin_endpoint(self):
-        container = self._get_admin_container()
-
-        if not container:
-            click.secho("No container found", fg="red", bold=True)
-            raise click.Abort()
-
+    def get_gateway_admin_endpoint(self) -> str:
+        container = self._get_admin_container_or_abort()
         return container.domain_name
 
-    def create_db(self):
+    def create_db(self, password: str) -> None:
         instance = self._get_database_instance()
 
         if instance:
@@ -192,16 +140,16 @@ class InfraManager(object):
         else:
             click.secho(f"Creating database instance {DB_INSTANCE_NAME}")
 
-            instance: Instance = self.rdb.create_instance(
+            instance = self.rdb.create_instance(
                 name=DB_INSTANCE_NAME,
                 engine=DB_ENGINE,
                 user_name=DB_USERNAME,
-                password=DB_PASSWORD,
+                password=password,
                 is_ha_cluster=False,
                 disable_backup=True,
                 backup_same_region=True,
                 node_type=DB_NODE_TYPE,
-                volume_type=DB_VOLUME_TYPE,
+                volume_type=rdb.VolumeType(DB_VOLUME_TYPE),
                 volume_size=DB_VOLUME_SIZE,
             )
 
@@ -214,22 +162,17 @@ class InfraManager(object):
 
         click.secho(f"Database status: {instance.status}", fg="green", bold=True)
 
-    def _do_await_db(self):
+    def await_db(self) -> None:
         instance = self._get_database_instance()
 
         if not instance:
-            return False
-
-        if instance.status == InstanceStatus.ERROR:
-            click.secho("Database in error", fg="red", bold="true")
+            click.secho("No database instance found", fg="red", bold=True)
             raise click.Abort()
-        elif instance.status != InstanceStatus.READY:
-            return False
 
-        return True
-
-    def await_db(self):
-        self._do_await(self._do_await_db)
+        instance = self.rdb.wait_for_instance(instance_id=instance.id)
+        if instance.status is not rdb.InstanceStatus.READY:
+            click.secho("Database is not ready", fg="red", bold="true")
+            raise click.Abort()
 
         click.secho("Database ready", fg="green", bold=True)
 
@@ -242,7 +185,6 @@ class InfraManager(object):
 
         click.secho(f"Creating namespace {CONTAINER_NAMESPACE}")
         self.containers.create_namespace(
-            region=API_REGION,
             name=CONTAINER_NAMESPACE,
         )
 
@@ -253,30 +195,31 @@ class InfraManager(object):
             click.secho("No namespace found", fg="red", bold="true")
             raise click.Abort()
 
-        if namespace.status == NamespaceStatus.ERROR:
+        if namespace.status == cnt.NamespaceStatus.ERROR:
             click.secho("Namespace in error", fg="red", bold="true")
             raise click.Abort()
 
         click.secho(f"Namespace status: {namespace.status}")
 
-    def _do_await_namespace(self):
-        namespace: Namespace = self._get_namespace()
+    def await_namespace(self):
+        namespace = self._get_namespace()
 
         if not namespace:
-            return False
-
-        if namespace.status == NamespaceStatus.ERROR:
-            click.secho("Namespace in error", fg="error", bold="true")
+            click.secho("No namespace found", fg="red", bold="true")
             raise click.Abort()
-        elif namespace.status != NamespaceStatus.READY:
-            return False
 
-        return True
+        namespace = self.containers.wait_for_namespace(namespace_id=namespace.id)
+        if namespace.status == cnt.NamespaceStatus.ERROR:
+            click.secho(
+                f"Namespace in error: {namespace.error_message}",
+                fg="error",
+                bold="true",
+            )
+            raise click.Abort()
 
-    def await_namespace(self):
-        self._do_await(self._do_await_namespace)
         click.secho("Namespace ready", fg="green", bold=True)
 
+    # refactor this
     def delete_namespace(self):
         namespace = self._get_namespace()
 
@@ -287,18 +230,22 @@ class InfraManager(object):
             namespace_id=namespace.id, region=namespace.region
         )
 
-    def _get_container_env_vars(self):
+    def _get_container_env_vars(self) -> tuple[dict[str, str], dict[str, str]]:
         instance = self._get_database_instance()
         if instance is None:
             click.secho("No database found", fg="red", bold="true")
             raise click.Abort()
 
+        endpoint = instance.endpoints[0]
+        host = endpoint.ip or endpoint.hostname
+        if not host:
+            raise ValueError("No database host found")
+
         container_env_vars = {
-            "KONG_PG_HOST": instance.endpoint.ip,
-            "KONG_PG_PORT": f"{instance.endpoint.port}",
+            "KONG_PG_HOST": host,
+            "KONG_PG_PORT": str(endpoint.port),
             "KONG_PG_DATABASE": DB_DATABASE_NAME,
             "KONG_PG_USER": DB_USERNAME,
-            "KONG_PG_PASSWORD": DB_PASSWORD,
         }
 
         admin_container_env_vars = copy.copy(container_env_vars)
@@ -306,13 +253,19 @@ class InfraManager(object):
 
         return admin_container_env_vars, container_env_vars
 
-    def create_containers(self):
+    def _get_container_secret_env_vars(self, db_password: str) -> list[cnt.Secret]:
+        return [cnt.Secret("KONG_PG_PASSWORD", db_password)]
+
+    def create_containers(self, db_password: str) -> None:
+        """Create containers for Kong and Kong Admin."""
+
         namespace = self._get_namespace()
         if namespace is None:
             click.secho("No namespace found", fg="red", bold="true")
             raise click.Abort()
 
         admin_container_env_vars, container_env_vars = self._get_container_env_vars()
+        secret_env_vars = self._get_container_secret_env_vars(db_password)
 
         admin_container = self._get_admin_container()
         if admin_container is not None:
@@ -326,24 +279,23 @@ class InfraManager(object):
                 bold="true",
             )
 
-            created_container: Container = self.containers.create_container(
+            created_container = self.containers.create_container(
                 namespace_id=namespace.id,
                 name=CONTAINER_ADMIN_NAME,
                 memory_limit=CONTAINER_ADMIN_MEMORY_LIMIT,
                 min_scale=CONTAINER_ADMIN_MIN_SCALE,
                 max_scale=CONTAINER_ADMIN_MAX_SCALE,
-                privacy=ContainerPrivacy.PRIVATE,
-                protocol=ContainerProtocol.HTTP1,
-                http_option=ContainerHttpOption.REDIRECTED,
+                privacy=cnt.ContainerPrivacy.PRIVATE,
+                protocol=cnt.ContainerProtocol.HTTP1,
+                http_option=cnt.ContainerHttpOption.REDIRECTED,
                 registry_image=IMAGE_TAG,
                 environment_variables=admin_container_env_vars,
+                secret_environment_variables=secret_env_vars,
             )
 
             click.secho(f"Deploying container {CONTAINER_ADMIN_NAME}")
 
-            self.containers.deploy_container(
-                container_id=created_container.id, region=API_REGION
-            )
+            self.containers.deploy_container(container_id=created_container.id)
 
         container = self._get_container()
         if container is not None:
@@ -351,23 +303,22 @@ class InfraManager(object):
         else:
             click.secho(f"Creating container {CONTAINER_NAME}")
 
-            created_container: Container = self.containers.create_container(
+            created_container = self.containers.create_container(
                 namespace_id=namespace.id,
                 name=CONTAINER_NAME,
                 memory_limit=CONTAINER_MEMORY_LIMIT,
                 min_scale=CONTAINER_MIN_SCALE,
                 max_scale=CONTAINER_MAX_SCALE,
-                privacy=ContainerPrivacy.PUBLIC,
-                protocol=ContainerProtocol.HTTP1,
-                http_option=ContainerHttpOption.REDIRECTED,
+                privacy=cnt.ContainerPrivacy.PUBLIC,
+                protocol=cnt.ContainerProtocol.HTTP1,
+                http_option=cnt.ContainerHttpOption.REDIRECTED,
                 registry_image=IMAGE_TAG,
                 environment_variables=container_env_vars,
+                secret_environment_variables=secret_env_vars,
             )
 
             click.secho(f"Deploying container {CONTAINER_NAME}")
-            self.containers.deploy_container(
-                container_id=created_container.id, region=API_REGION
-            )
+            self.containers.deploy_container(container_id=created_container.id)
 
     def delete_containers(self):
         admin_container = self._get_admin_container()
@@ -375,129 +326,95 @@ class InfraManager(object):
 
         if admin_container:
             click.secho(f"Deleting container {CONTAINER_ADMIN_NAME}")
-            self.containers.delete_container(
-                container_id=admin_container.id, region=API_REGION
-            )
+            self.containers.delete_container(container_id=admin_container.id)
 
         if container:
             click.secho(f"Deleting container {CONTAINER_NAME}")
-            self.containers.delete_container(
-                container_id=container.id, region=API_REGION
-            )
+            self.containers.delete_container(container_id=container.id)
 
     def check_containers(self):
-        admin_container = self._get_admin_container()
-        container = self._get_container()
-
-        if admin_container is None:
-            click.secho("No admin container found", fg="red", bold="true")
-
-        if container is None:
-            click.secho("No container found", fg="red", bold="true")
-
-        if admin_container is None or container is None:
-            raise click.Abort()
+        admin_container = self._get_admin_container_or_abort()
+        container = self._get_container_or_abort()
 
         click.secho(f"Admin container status: {admin_container.status}")
         click.secho(f"Container status: {container.status}")
 
-    def _do_await_containers(self):
-        admin_container = self._get_admin_container()
-        container = self._get_container()
-
-        if not admin_container:
-            return False
-
-        if not container:
-            return False
-
-        if admin_container.status == ContainerStatus.ERROR:
-            click.secho("Admin container in error", fg="red", bold=True)
-            raise click.Abort()
-        elif admin_container.status != ContainerStatus.READY:
-            return False
-
-        if container.status == ContainerStatus.ERROR:
-            click.secho("Container in error", fg="red", bold=True)
-            raise click.Abort()
-        elif container.status != ContainerStatus.READY:
-            return False
-
-        return True
-
     def await_containers(self):
-        self._do_await(self._do_await_containers)
+        admin_container = self._get_admin_container_or_abort()
+        container = self._get_container_or_abort()
+
+        # Execute in parallel
+        results = futures.ThreadPoolExecutor(max_workers=2).map(
+            self.containers.wait_for_container, [admin_container.id, container.id]
+        )
+        for res in results:
+            if res.status == cnt.ContainerStatus.ERROR:
+                click.secho(
+                    f"Container {res.name} is in error: {res.error_message}"
+                    "Check the logs for more details.",
+                    fg="red",
+                    bold=True,
+                )
+                raise click.Abort()
+            if res.status != cnt.ContainerStatus.READY:
+                click.secho(f"Container {res.name} is not ready", fg="red", bold=True)
+                raise click.Abort()
 
         click.secho("Containers ready", fg="green", bold=True)
 
-    def create_admin_container_token(self):
-        admin_container = self._get_admin_container()
-
-        if admin_container is None:
-            click.secho("No admin container found", fg="red", bold="true")
-            raise click.Abort()
-
-        token: Token = self.containers.create_token(
-            region=API_REGION, container_id=admin_container.id
-        )
-
+    def create_admin_container_token(self) -> str:
+        admin_container = self._get_admin_container_or_abort()
+        token = self.containers.create_token(container_id=admin_container.id)
         return token.token
 
-    def update_container(self):
-        self.update_container_without_deploy()
+    def update_container(self, db_password: str):
+        self.update_container_without_deploy(db_password=db_password)
 
-        admin_container = self._get_admin_container()
-        container = self._get_container()
+        admin_container = self._get_admin_container_or_abort()
+        container = self._get_container_or_abort()
 
-        click.secho("Deploying admin container")
-        self.containers.deploy_container(
-            container_id=admin_container.id, region=API_REGION
-        )
+        click.secho("Deploying admin container...")
+        self.containers.deploy_container(container_id=admin_container.id)
 
-        click.secho("Deploying container")
-        self.containers.deploy_container(container_id=container.id, region=API_REGION)
+        click.secho("Deploying container...")
+        self.containers.deploy_container(container_id=container.id)
 
-    def update_container_without_deploy(self):
-        admin_container = self._get_admin_container()
-        container = self._get_container()
-
-        if not admin_container:
-            click.secho("Admin container does not exist", fg="red", bold=True)
-            raise click.Abort()
-
-        if not container:
-            click.secho("Container does not exist", fg="red", bold=True)
-            raise click.Abort()
+    def update_container_without_deploy(self, db_password: str):
+        admin_container = self._get_admin_container_or_abort()
+        container = self._get_container_or_abort()
 
         container_admin_env_vars, container_env_vars = self._get_container_env_vars()
+        secret_env_vars = self._get_container_secret_env_vars(db_password)
 
         click.secho("Updating admin container")
 
         self.containers.update_container(
             container_id=admin_container.id,
-            privacy=ContainerPrivacy.PRIVATE,
+            privacy=cnt.ContainerPrivacy.PRIVATE,
             memory_limit=CONTAINER_ADMIN_MEMORY_LIMIT,
             min_scale=CONTAINER_ADMIN_MIN_SCALE,
             max_scale=CONTAINER_ADMIN_MAX_SCALE,
-            protocol=ContainerProtocol.HTTP1,
-            http_option=ContainerHttpOption.REDIRECTED,
+            protocol=cnt.ContainerProtocol.HTTP1,
+            http_option=cnt.ContainerHttpOption.REDIRECTED,
             registry_image=IMAGE_TAG,
             environment_variables=container_admin_env_vars,
+            secret_environment_variables=secret_env_vars,
         )
 
         click.secho("Updating container")
 
         self.containers.update_container(
             container_id=container.id,
-            privacy=ContainerPrivacy.PRIVATE,
+            privacy=cnt.ContainerPrivacy.PRIVATE,
             memory_limit=CONTAINER_MEMORY_LIMIT,
             min_scale=CONTAINER_MIN_SCALE,
             max_scale=CONTAINER_MAX_SCALE,
-            protocol=ContainerProtocol.HTTP1,
-            http_option=ContainerHttpOption.REDIRECTED,
+            protocol=cnt.ContainerProtocol.HTTP1,
+            http_option=cnt.ContainerHttpOption.REDIRECTED,
             registry_image=IMAGE_TAG,
             environment_variables=container_env_vars,
+            secret_environment_variables=secret_env_vars,
         )
 
     def set_custom_domain(self):
-        pass
+        raise NotImplementedError

--- a/cli/tests/integration/environment.py
+++ b/cli/tests/integration/environment.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from cli.infra import InfraManager
+from cli.client import get_scaleway_client
 
 FUNC_FIXTURE_NAME = "func-a"
 FUNC_FIXTURE_NAMESPACE = "function-fixtures"
@@ -34,7 +35,8 @@ class IntegrationEnvironment:
 
     @staticmethod
     def get_scw_env():
-        manager = InfraManager()
+        scw_client = get_scaleway_client()
+        manager = InfraManager(scw_client=scw_client)
 
         func_a_endpoint = manager.get_function_endpoint(
             FUNC_FIXTURE_NAMESPACE, FUNC_FIXTURE_NAME

--- a/cli/tests/integration/test_routes.py
+++ b/cli/tests/integration/test_routes.py
@@ -197,7 +197,7 @@ class TestEndpoint(object):
         route = Route("/foo", target)
 
         resp = self.manager.add_route(route)
-        assert resp.status_code == requests.status_codes.codes.ok
+        assert resp.status_code == requests.codes.ok
 
         # Get route
         routes = self.manager.get_routes()

--- a/gateway/config/kong-admin.conf
+++ b/gateway/config/kong-admin.conf
@@ -1,8 +1,8 @@
 database = postgres
 
-admin_listen = 0.0.0.0:8080, 0.0.0.0:8444 ssl
+admin_listen = 0.0.0.0:8001 reuseport
 admin_access_log = /dev/stdout
 admin_error_log = /dev/stderr
 
-prefix: /var/run/kong
+prefix = /var/run/kong
 log_level = info


### PR DESCRIPTION
## Summary

**_What's changed?_**

Added password generation to avoid a fixed password.

**_Why do we need this?_**

Make it more "production ready".

**_How have you tested it?_**

Ran the README commands with the changes.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation
- [ ] I have upgraded the VERSION file to push the gateway image with a new tag <- not relevant

## Details

Main changes:
- Added some utilities to generate a database password
- Password can be stored in Secret Manager for subsequent use or just passed via an env var.

Unrelated changes:
- Changed the waiters to use the ones from the SDK (something we discussed with Simon)
- Removed region in API calls as setting it in the client is less error-prone. Also, it makes it possible to use with regions other than fr-par
- Fixed a lot of mypy / pylance type-checking warnings