### PR TITLE
chore: change image to 0.2.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,5 @@
 - [ ] I have reviewed this myself
 - [ ] There is a unit test covering every change in this PR
 - [ ] I have updated the relevant documentation
-- [ ] I have upgraded the VERSION file to push the gateway image with a new tag
 
 ## Details

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -19,5 +19,5 @@ runs:
     - name: Install poetry dependencies
       shell: bash
       working-directory: cli
-      run: poetry install --no-interaction --no-root --with=dev
+      run: poetry install --no-interaction --with=dev
       if: steps.cache-gw-deps.outputs.cache-hit != 'true'

--- a/cli/cli/infra/image.py
+++ b/cli/cli/infra/image.py
@@ -1,5 +1,5 @@
 IMAGE_REGISTRY = "docker.io"
 IMAGE_ORG = "scaleway"
 IMAGE_NAME = "serverless-gateway"
-IMAGE_VERSION = "0.2"
+IMAGE_VERSION = "0.2.0"
 IMAGE_TAG = f"{IMAGE_REGISTRY}/{IMAGE_ORG}/{IMAGE_NAME}:{IMAGE_VERSION}"

--- a/cli/cli/infra/image.py
+++ b/cli/cli/infra/image.py
@@ -1,5 +1,11 @@
+from importlib.metadata import version
+
 IMAGE_REGISTRY = "docker.io"
 IMAGE_ORG = "scaleway"
 IMAGE_NAME = "serverless-gateway"
-IMAGE_VERSION = "0.2.0"
+
+# Single source of truth for the image version
+# is the version of the package
+IMAGE_VERSION = version("scw-gateway")
+
 IMAGE_TAG = f"{IMAGE_REGISTRY}/{IMAGE_ORG}/{IMAGE_NAME}:{IMAGE_VERSION}"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "scw-gateway"
-version = "0.1.2"
-description = ""
+version = "0.2.0"
+description = "CLI to deploy and manage a self-hosted Kong gateway on Scaleway Serverless Ecosystem"
 authors = ["Simon Shillaker <sshillaker@scaleway.com>"]
 readme = "README.md"
 packages = [{include = "cli"}]
@@ -42,5 +42,3 @@ testpaths = ["tests"]
 
 [tool.mypy]
 exclude = ["venv", "endpoints"]
-# TODO - enable mypy checking properly and fix issue with kong_pdk
-ignore_missing_imports = true


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Update image & CLI tag to 0.2.0 to prepare for release

**_Why do we need this?_**

- To release 0.2.0 version

**_How have you tested it?_**

- Integration tests working, but proper tests with images require a release :rocket: 

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
