### PR TITLE
fix(cli): flaky gateway configuration after redeploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `deploy` command to deploy all gateway components in a single command
 - Added `--http-methods` flag to `add-route` command to specify http methods
+
+## [0.3.1] - 2023-06-27
+
+### Fixed
+
+- Fixed gateway manager failing after deploying due to token refresh desync

--- a/cli/cli/gateway.py
+++ b/cli/cli/gateway.py
@@ -25,7 +25,7 @@ def response_hook(response: requests.Response, *_args, **_kwargs):
             logger.error(f"Error: \n{json.dumps(body_json, indent=2)}")
         except json.decoder.JSONDecodeError:
             logger.error(f"Error: \n{err.response.text}")
-        raise
+        raise err
 
 
 class GatewayManager:

--- a/cli/cli/gateway.py
+++ b/cli/cli/gateway.py
@@ -4,9 +4,13 @@ from typing import List
 import click
 import requests
 from loguru import logger
+from requests.adapters import HTTPAdapter
+from urllib3 import Retry
 
 from cli import conf
 from cli.model import Route
+
+MAX_RETRIES = 5
 
 
 def response_hook(response: requests.Response, *_args, **_kwargs):
@@ -16,8 +20,11 @@ def response_hook(response: requests.Response, *_args, **_kwargs):
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
-        body_json = err.response.json()
-        logger.error(f"Error: \n{json.dumps(body_json, indent=2)}")
+        try:  # Try to parse the body as JSON
+            body_json = err.response.json()
+            logger.error(f"Error: \n{json.dumps(body_json, indent=2)}")
+        except json.decoder.JSONDecodeError:
+            logger.error(f"Error: \n{err.response.text}")
         raise
 
 
@@ -59,11 +66,24 @@ class GatewayManager:
         self.services_url = self.admin_url + "/services"
         self.token = self.config.gw_admin_token
 
+        self._create_session()
+
+    def _create_session(self):
         self.session = requests.Session()
         if self.token:
             self.session.headers["X-Auth-Token"] = self.token
         self.session.headers["Content-Type"] = "application/json"
         self.session.hooks["response"].append(response_hook)
+
+        retries = Retry(
+            total=MAX_RETRIES,
+            backoff_factor=2,
+            status=MAX_RETRIES,  # Status max retries
+            # 403: retry for token refresh
+            # 404: retry for Envoy service not found
+            status_forcelist=[500, 404, 403],
+        )
+        self.session.mount("https://", HTTPAdapter(max_retries=retries))
 
     def add_route(self, route: Route):
         service_url = f"{self.services_url}/{route.name}"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scw-gateway"
-version = "0.3.0"
+version = "0.3.1"
 description = "CLI to deploy and manage a self-hosted Kong gateway on Scaleway Serverless Ecosystem"
 authors = ["Simon Shillaker <sshillaker@scaleway.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

**_What's changed?_**

- When doing `scw-serverless deploy`, the step `Enabling metrics` can be flaky and sometimes fail with a 403 from envoy. Currently, since this is not a json this crashes the CLI and in addition, is not properly handled (we should retry / wait for the gateway to be running)

**_Why do we need this?_**

- Make `scwgw deploy` more reliable

**_How have you tested it?_**

- Ran `scwgw deploy` a few times and did not get the 403 issue

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
