### PR TITLE
chore: bump version to 0.4.0 for api-framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed gateway manager failing after deploying due to token refresh desync
+
+## [0.4.0] - 2023-07-03
+
+### Added
+
+- Added CLI support to easily manage JWT authentification to the routes. Please refer to the [auth documentation](./docs/auth.md) for more information on usage.
+
+### Changed
+
+- Grouped CLI commands thematically. The gateway infastructure management is now split from the gateway configuration via different CLI command group.

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "scw-gateway"
-version = "0.3.1"
+version = "0.4.0"
 description = "CLI to deploy and manage a self-hosted Kong gateway on Scaleway Serverless Ecosystem"
 authors = ["Simon Shillaker <sshillaker@scaleway.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary

**_What's changed?_**

- A small MR to bump the gateway version and changelog. This is just to release the API framework version with the breaking change (add-route became route add).

**_Why do we need this?_**

- Release breaking changes for API framework integration

**_How have you tested it?_**

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation

## Details
