### PR TITLE
Custom domains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,5 +48,5 @@ jobs:
         working-directory: cli
 
       - name: Run the tests
-        run: poetry run pytest tests/integration
+        run: poetry run pytest -m "not deployed" tests/integration
         working-directory: cli

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -24,5 +24,8 @@ test:
 
 .PHONY: test-int
 test-int:
-	poetry run pytest tests/integration
+	poetry run pytest -m "not deployed" tests/integration
 
+.PHONY: test-int-deployed
+test-int-deployed:
+	poetry run pytest tests/integration

--- a/cli/cli/cli.py
+++ b/cli/cli/cli.py
@@ -5,6 +5,7 @@ from loguru import logger
 
 from cli.commands.consumer import consumer as consumer_commands
 from cli.commands.dev import dev as dev_commands
+from cli.commands.domain import domain as domain_commands
 from cli.commands.infra import infra as infra_commands
 from cli.commands.jwt import jwt as jwt_commands
 from cli.commands.route import route as route_commands
@@ -31,6 +32,7 @@ def cli():
 
 cli.add_command(consumer_commands)
 cli.add_command(dev_commands)
+cli.add_command(domain_commands)
 cli.add_command(infra_commands)
 cli.add_command(jwt_commands)
 cli.add_command(route_commands)

--- a/cli/cli/commands/domain.py
+++ b/cli/cli/commands/domain.py
@@ -30,7 +30,7 @@ def add(domain):
 @domain.command()
 @click.argument("domain")
 def delete(domain):
-    """Removes a domain from the gateway"""
+    """Remove a domain from the gateway"""
     scw_client = client.get_scaleway_client()
     manager = InfraManager(scw_client)
     manager.delete_custom_domain(domain)

--- a/cli/cli/commands/domain.py
+++ b/cli/cli/commands/domain.py
@@ -1,0 +1,36 @@
+import click
+
+from cli import client
+from cli.infra import InfraManager
+
+
+@click.group()
+def domain():
+    """Manage gateway domains"""
+    pass
+
+
+@domain.command()
+def ls():
+    """Print the domains configured on the gateway"""
+    scw_client = client.get_scaleway_client()
+    manager = InfraManager(scw_client)
+    manager.print_domains_for_container()
+
+
+@domain.command()
+@click.argument("domain")
+def add(domain):
+    """Add a domain to the gateway"""
+    scw_client = client.get_scaleway_client()
+    manager = InfraManager(scw_client)
+    manager.add_custom_domain(domain)
+
+
+@domain.command()
+@click.argument("domain")
+def delete(domain):
+    """Removes a domain from the gateway"""
+    scw_client = client.get_scaleway_client()
+    manager = InfraManager(scw_client)
+    manager.delete_custom_domain(domain)

--- a/cli/cli/commands/infra.py
+++ b/cli/cli/commands/infra.py
@@ -92,6 +92,15 @@ def endpoint():
 
 
 @infra.command()
+def ip():
+    """Print the IP for the gateway"""
+    scw_client = client.get_scaleway_client()
+    manager = InfraManager(scw_client)
+    endpoint = manager.get_gateway_ip()
+    click.secho(endpoint)
+
+
+@infra.command()
 def admin_endpoint():
     """Print the endpoint for the gateway admin"""
     scw_client = client.get_scaleway_client()

--- a/cli/cli/commands/route.py
+++ b/cli/cli/commands/route.py
@@ -1,8 +1,6 @@
 import click
 
-from cli import client
 from cli.gateway import GatewayManager
-from cli.infra import InfraManager
 from cli.model import Route
 
 
@@ -55,11 +53,3 @@ def delete(relative_url, target):
 
     route = Route(relative_url, target)
     manager.delete_route(route)
-
-
-@route.command()
-def custom_domain():
-    """Set the custom domain for the gateway"""
-    scw_client = client.get_scaleway_client()
-    manager = InfraManager(scw_client)
-    manager.set_custom_domain()

--- a/cli/cli/infra/container.py
+++ b/cli/cli/infra/container.py
@@ -1,3 +1,4 @@
+import click
 import scaleway.container.v1beta1 as sdk
 
 from cli.conf import DB_DATABASE_NAME

--- a/cli/cli/infra/container.py
+++ b/cli/cli/infra/container.py
@@ -1,4 +1,3 @@
-import click
 import scaleway.container.v1beta1 as sdk
 
 from cli.conf import DB_DATABASE_NAME

--- a/cli/cli/infra/manager.py
+++ b/cli/cli/infra/manager.py
@@ -414,6 +414,36 @@ class InfraManager:
             metrics_push_url=metrics_push_url,
         )
 
-    def set_custom_domain(self):
+    def print_domains_for_container(self) -> None:
+        """Prints the custom domains set on the container"""
+        container = self._get_container_or_abort()
+        domains = self.containers.list_domains_all(container_id=container.id)
+
+        click.secho(f"{'HOSTNAME':<40} {'URL':<45} {'STATUS':<10}", bold=True)
+        for d in domains:
+            click.secho(f"{d.hostname:<40} {d.url:<45} {d.status:<10}")
+
+    def add_custom_domain(self, domain: str):
         """Set a custom domain for the container."""
-        raise NotImplementedError
+        container = self._get_container_or_abort()
+        domains = self.containers.list_domains_all(container_id=container.id)
+
+        for d in domains:
+            if d.hostname == domain:
+                click.echo("Container domain already exists, deleting")
+                self.containers.delete_domain(domain_id=d.id)
+
+        click.echo(f"Adding domain {domain}")
+        domain = self.containers.create_domain(
+            hostname=domain, container_id=container.id
+        )
+
+    def delete_custom_domain(self, domain: str):
+        """Delete a custom domain for the container."""
+        container = self._get_container_or_abort()
+        domains = self.containers.list_domains_all(container_id=container.id)
+
+        for d in domains:
+            if d.hostname == domain:
+                click.echo(f"Deleting domain {domain}")
+                self.containers.delete_domain(domain_id=d.id)

--- a/cli/cli/infra/manager.py
+++ b/cli/cli/infra/manager.py
@@ -434,9 +434,7 @@ class InfraManager:
                 self.containers.delete_domain(domain_id=d.id)
 
         click.echo(f"Adding domain {domain}")
-        domain = self.containers.create_domain(
-            hostname=domain, container_id=container.id
-        )
+        self.containers.create_domain(hostname=domain, container_id=container.id)
 
     def delete_custom_domain(self, domain: str):
         """Delete a custom domain for the container."""

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -48,6 +48,9 @@ profile = "black"
 log_cli = true
 log_cli_level = "INFO"
 testpaths = ["tests"]
+markers = [
+  "deployed: Integration tests for a fully deployed environment",
+]
 
 [tool.mypy]
 exclude = ["venv", "endpoints"]

--- a/cli/tests/integration/common.py
+++ b/cli/tests/integration/common.py
@@ -1,0 +1,96 @@
+import contextlib
+import json
+import time
+
+import pytest
+import requests
+from loguru import logger
+from scaleway import Client
+
+from cli import client
+from cli.gateway import GatewayManager
+from cli.infra import InfraManager
+from cli.model import Route
+from tests.integration.environment import IntegrationEnvironment
+
+
+class GatewayTest:
+    env: IntegrationEnvironment
+    manager: GatewayManager
+    infra: InfraManager
+    scw_client: Client
+
+    @staticmethod
+    @pytest.fixture(autouse=True, scope="class")
+    def setup(integration_env: IntegrationEnvironment):
+        GatewayTest.env = integration_env
+        GatewayTest.manager = GatewayManager()
+        GatewayTest.scw_client = client.get_scaleway_client()
+        GatewayTest.infra = InfraManager(GatewayTest.scw_client)
+
+    @contextlib.contextmanager
+    def add_route_to_fixture(
+        self,
+        relative_url: str,
+        http_methods: list[str] | None = None,
+        cors: bool = False,
+        jwt: bool = False,
+    ):
+        """Context manager to add a route and remove it."""
+        route = Route(
+            relative_url,
+            self.env.gw_func_a_url,
+            http_methods=http_methods,
+            cors=cors,
+            jwt=jwt,
+        )
+
+        # Make sure it's deleted first
+        self.manager.delete_route(route)
+
+        # Now add the route
+        resp = self.manager.add_route(route)
+        resp.raise_for_status()
+
+        yield relative_url
+
+        resp = self.manager.delete_route(route)
+        resp.raise_for_status()
+
+    @staticmethod
+    def call_endpoint_until_response_code(url, code, method: str = "GET", headers=None):
+        max_retries = 10
+        sleep_time = 2
+
+        for _ in range(max_retries):
+            resp = requests.request(method=method, url=url, headers=headers)
+            if resp.status_code == code:
+                logger.info(f"Got {resp.status_code} from {url}")
+                return resp
+
+            logger.info(
+                f"Got {resp.status_code} from {url}, retrying, message: {resp.text}"
+            )
+            time.sleep(sleep_time)
+
+        # Here we have failed
+        raise RuntimeError(f"Did not get {code} from {url} in {max_retries} tries")
+
+    @staticmethod
+    def call_endpoint_until_gw_message(url, message):
+        max_retries = 5
+        sleep_time = 2
+
+        for _ in range(max_retries):
+            resp = requests.get(url)
+            if json.loads(resp.content)["message"] == message:
+                recieved_message = json.loads(resp.content)["message"]
+                logger.info(f"Got {recieved_message} from {url}")
+                return resp
+
+            recieved_message = json.loads(resp.content)["message"]
+            logger.info(f"Got {recieved_message} from {url}, retrying")
+            time.sleep(sleep_time)
+
+        # Here we have failed
+        raise RuntimeError(f"Did not get {message} from {url} in {max_retries} tries")

--- a/cli/tests/integration/test_domains.py
+++ b/cli/tests/integration/test_domains.py
@@ -16,8 +16,7 @@ class TestDomains(GatewayTest):
         scw_client = client.get_scaleway_client()
         manager = InfraManager(scw_client)
 
-        # Add custom domain using nip.io
-        # https://nip.io/
+        # Add custom domain using nip.io: https://nip.io/
         gw_ip = manager.get_gateway_ip()
         custom_domain = f"{gw_ip}.nip.io"
 
@@ -44,19 +43,21 @@ class TestDomains(GatewayTest):
         # Add a route
         relative_url = "/cd-test"
         with self.add_route_to_fixture(relative_url):
-            # Check call directly
+            # Call directly
             default_url = f"{self.env.gw_url}{relative_url}/hello"
             resp_default = self.call_endpoint_until_response_code(
                 default_url,
                 requests.codes.ok,
             )
 
+            # Call via domain
             full_url = f"https://{custom_domain}{relative_url}/hello"
             resp_domain = self.call_endpoint_until_response_code(
                 full_url,
                 requests.codes.ok,
             )
 
+            # Check responses are the same
             assert resp_default.content == resp_domain.content
 
         # Remove the domain from the gateway

--- a/cli/tests/integration/test_domains.py
+++ b/cli/tests/integration/test_domains.py
@@ -1,0 +1,134 @@
+import time
+
+import pytest
+from scaleway import ScalewayException
+from scaleway.domain import v2beta1 as dom
+
+from cli import client
+from cli.infra import InfraManager
+
+DOMAIN_ZONE = "scw.cloud"
+SUBDOMAIN = "gateway-oss.fnc.dev.fr-par"
+FULL_HOSTNAME = f"{SUBDOMAIN}.{DOMAIN_ZONE}"
+
+
+class DomainManager:
+    def __init__(self):
+        self.scw_client = client.get_scaleway_client()
+        self.domain = dom.DomainV2Beta1API(self.scw_client)
+
+        self.org_id = self.scw_client.default_organization_id
+
+    def get_dns_zone(self) -> dom.DNSZone:
+        zones = self.domain.list_dns_zones_all(
+            domain=DOMAIN_ZONE, dns_zone=DOMAIN_ZONE, project_id=self.org_id
+        )
+
+        matches = [z for z in zones if z.subdomain == SUBDOMAIN]
+        if len(matches) != 1:
+            pytest.fail(
+                msg="Did not find a zone with subdomain {SUBDOMAIN}. Got: {zones}"
+            )
+
+        return matches[0]
+
+    def add_cname_to_zone(self, cname_name: str, target: str):
+        changes = [
+            dom.RecordChange(
+                add=dom.RecordChangeAdd(
+                    records=[
+                        dom.DomainRecord(
+                            data=cname_name,
+                            name=target,
+                            priority=0,
+                            ttl=600,
+                            comment="Record for integration test",
+                            type_=dom.DomainRecordType.CNAME,
+                            geo_ip_config=None,
+                            http_service_config=None,
+                            weighted_config=None,
+                            view_config=None,
+                            id="",
+                        )
+                    ]
+                ),
+                set_=None,
+                delete=None,
+                clear=None,
+            ),
+        ]
+
+        self.domain.update_dns_zone_records(
+            dns_zone=FULL_HOSTNAME,
+            changes=changes,
+            disallow_new_zone_creation=True,
+        )
+
+    def get_cname_from_zone(self, cname_name: str):
+        records = self.domain.list_dns_zone_records_all(
+            dns_zone=FULL_HOSTNAME,
+            name=cname_name,
+            project_id=self.org_id,
+        )
+
+        if len(records) != 1:
+            pytest.fail(f"Expected 1 DNS record, got {records}")
+
+        return records[0]
+
+    def delete_cname_from_zone(self, cname_name: str):
+        zone = self.get_cname_from_zone(cname_name)
+
+        changes = [
+            dom.RecordChange(
+                delete=dom.RecordChangeDelete(
+                    id=zone.id,
+                    id_fields=None,
+                ),
+                set_=None,
+                add=None,
+                clear=None,
+            ),
+        ]
+
+        self.domain.update_dns_zone_records(
+            dns_zone=FULL_HOSTNAME,
+            changes=changes,
+            disallow_new_zone_creation=True,
+        )
+
+
+def test_adding_domain():
+    scw_client = client.get_scaleway_client()
+    manager = InfraManager(scw_client)
+    endpoint = manager.get_gateway_endpoint()
+
+    # Set up a new CNAME
+    mgr = DomainManager()
+    cname_name = "gateway-test"
+    mgr.add_cname_to_zone(cname_name, endpoint)
+
+    # Keep trying to add domain to the gateway, will take time to propagate and validate
+    success = False
+    exception = None
+    for retry in range(5):
+        time.sleep(10)
+        try:
+            container_hostname = f"{cname_name}.{FULL_HOSTNAME}"
+            manager.add_custom_domain(container_hostname)
+
+            success = True
+            break
+        except ScalewayException as e:
+            exception = e
+
+    if not success:
+        raise exception
+
+    # TODO - make a request
+
+    # Remove the domain from the gateway
+    # manager.delete_custom_domain(FULL_HOSTNAME)
+
+    # Delete the CNAME
+    # mgr.delete_cname_from_zone(cname_name)

--- a/cli/tests/integration/test_domains.py
+++ b/cli/tests/integration/test_domains.py
@@ -1,134 +1,60 @@
 import time
 
-import pytest
+import requests
 from scaleway import ScalewayException
-from scaleway.domain import v2beta1 as dom
 
 from cli import client
 from cli.infra import InfraManager
-
-DOMAIN_ZONE = "scw.cloud"
-SUBDOMAIN = "gateway-oss.fnc.dev.fr-par"
-FULL_HOSTNAME = f"{SUBDOMAIN}.{DOMAIN_ZONE}"
+from tests.integration.common import GatewayTest
 
 
-class DomainManager:
-    def __init__(self):
-        self.scw_client = client.get_scaleway_client()
-        self.domain = dom.DomainV2Beta1API(self.scw_client)
+class TestDomains(GatewayTest):
+    def test_adding_domain(self):
+        scw_client = client.get_scaleway_client()
+        manager = InfraManager(scw_client)
 
-        self.org_id = self.scw_client.default_organization_id
+        # Add custom domain using nip.io
+        # https://nip.io/
+        gw_ip = manager.get_gateway_ip()
+        custom_domain = f"{gw_ip}.nip.io"
 
-    def get_dns_zone(self) -> dom.DNSZone:
-        zones = self.domain.list_dns_zones_all(
-            domain=DOMAIN_ZONE, dns_zone=DOMAIN_ZONE, project_id=self.org_id
-        )
+        # Add domain to the gateway
+        # Retry as it will take time to propagate and validate
+        success = False
+        exception = None
+        for retry in range(5):
+            time.sleep(10)
+            try:
+                manager.add_custom_domain(custom_domain)
 
-        matches = [z for z in zones if z.subdomain == SUBDOMAIN]
-        if len(matches) != 1:
-            pytest.fail(
-                msg="Did not find a zone with subdomain {SUBDOMAIN}. Got: {zones}"
+                success = True
+                break
+            except ScalewayException as e:
+                exception = e
+
+        if not success:
+            raise exception
+
+        # Wait for domain to be ready
+        manager.await_custom_domain(custom_domain)
+
+        # Add a route
+        relative_url = "/cd-test"
+        with self.add_route_to_fixture(relative_url):
+            # Check call directly
+            default_url = f"{self.env.gw_url}{relative_url}/hello"
+            resp_default = self.call_endpoint_until_response_code(
+                default_url,
+                requests.codes.ok,
             )
 
-        return matches[0]
+            full_url = f"https://{custom_domain}{relative_url}/hello"
+            resp_domain = self.call_endpoint_until_response_code(
+                full_url,
+                requests.codes.ok,
+            )
 
-    def add_cname_to_zone(self, cname_name: str, target: str):
-        changes = [
-            dom.RecordChange(
-                add=dom.RecordChangeAdd(
-                    records=[
-                        dom.DomainRecord(
-                            data=cname_name,
-                            name=target,
-                            priority=0,
-                            ttl=600,
-                            comment="Record for integration test",
-                            type_=dom.DomainRecordType.CNAME,
-                            geo_ip_config=None,
-                            http_service_config=None,
-                            weighted_config=None,
-                            view_config=None,
-                            id="",
-                        )
-                    ]
-                ),
-                set_=None,
-                delete=None,
-                clear=None,
-            ),
-        ]
+            assert resp_default.content == resp_domain.content
 
-        self.domain.update_dns_zone_records(
-            dns_zone=FULL_HOSTNAME,
-            changes=changes,
-            disallow_new_zone_creation=True,
-        )
-
-    def get_cname_from_zone(self, cname_name: str):
-        records = self.domain.list_dns_zone_records_all(
-            dns_zone=FULL_HOSTNAME,
-            name=cname_name,
-            project_id=self.org_id,
-        )
-
-        if len(records) != 1:
-            pytest.fail(f"Expected 1 DNS record, got {records}")
-
-        return records[0]
-
-    def delete_cname_from_zone(self, cname_name: str):
-        zone = self.get_cname_from_zone(cname_name)
-
-        changes = [
-            dom.RecordChange(
-                delete=dom.RecordChangeDelete(
-                    id=zone.id,
-                    id_fields=None,
-                ),
-                set_=None,
-                add=None,
-                clear=None,
-            ),
-        ]
-
-        self.domain.update_dns_zone_records(
-            dns_zone=FULL_HOSTNAME,
-            changes=changes,
-            disallow_new_zone_creation=True,
-        )
-
-
-def test_adding_domain():
-    scw_client = client.get_scaleway_client()
-    manager = InfraManager(scw_client)
-    endpoint = manager.get_gateway_endpoint()
-
-    # Set up a new CNAME
-    mgr = DomainManager()
-    cname_name = "gateway-test"
-    mgr.add_cname_to_zone(cname_name, endpoint)
-
-    # Keep trying to add domain to the gateway, will take time to propagate and validate
-    success = False
-    exception = None
-    for retry in range(5):
-        time.sleep(10)
-        try:
-            container_hostname = f"{cname_name}.{FULL_HOSTNAME}"
-            manager.add_custom_domain(container_hostname)
-
-            success = True
-            break
-        except ScalewayException as e:
-            exception = e
-
-    if not success:
-        raise exception
-
-    # TODO - make a request
-
-    # Remove the domain from the gateway
-    # manager.delete_custom_domain(FULL_HOSTNAME)
-
-    # Delete the CNAME
-    # mgr.delete_cname_from_zone(cname_name)
+        # Remove the domain from the gateway
+        manager.delete_custom_domain(custom_domain)

--- a/cli/tests/integration/test_domains.py
+++ b/cli/tests/integration/test_domains.py
@@ -1,11 +1,10 @@
 import time
 
+import pytest
 import requests
 from scaleway import ScalewayException
 
 from cli import client
-import pytest
-
 from cli.infra import InfraManager
 from tests.integration.common import GatewayTest
 

--- a/cli/tests/integration/test_domains.py
+++ b/cli/tests/integration/test_domains.py
@@ -4,10 +4,13 @@ import requests
 from scaleway import ScalewayException
 
 from cli import client
+import pytest
+
 from cli.infra import InfraManager
 from tests.integration.common import GatewayTest
 
 
+@pytest.mark.deployed
 class TestDomains(GatewayTest):
     def test_adding_domain(self):
         scw_client = client.get_scaleway_client()

--- a/docs/source/domains.md
+++ b/docs/source/domains.md
@@ -1,7 +1,45 @@
-# Custom domains
+# Custom domain
 
-You can add a custom domain to your gateway as with any other Serverless Container.
+Instead of using the default domain assigned to your gateway, you can add your own custom domains.
 
-You can register a new domain as described in the [Domains and DNS docs](https://www.scaleway.com/en/docs/network/domains-and-dns/quickstart/).
+You can use domains you already own, or register new ones (e.g. via the Scaleway [Domains and DNS](https://www.scaleway.com/en/docs/network/domains-and-dns/quickstart/) service).
 
-TODO: fill in details
+## Configuring your domain
+
+Configuring domains is done via a [Serverless Container custom domain](https://www.scaleway.com/en/docs/serverless/containers/how-to/add-a-custom-domain-to-a-container/).
+
+To add a domain to your gateway:
+
+1. Add a CNAME record from your domain that points to your gateway endpoint
+2. Run the CLI command `scwgw domain add <hostname of CNAME record>`
+
+### Example
+
+Start by getting the default endpoint for your gateway (this will be the target of the CNAME):
+
+```
+scwgw infra endpoint
+```
+
+This gives an output of the form `scwslsgwiaytodoc-scw-sls-gw.functions.fnc.fr-par.scw.cloud`.
+
+If your domain is `my-domain.com`, you can add a new CNAME record in your DNS provider that points to your gateway, e.g. `gateway.my-domain.com`:
+
+```
+CNAME     gateway.my-domain.com     scwslsgwiaytodoc-scw-sls-gw.functions.fnc.fr-par.scw.cloud
+```
+
+Once this has been propagated, you can add the domain to your gateway with:
+
+```
+scwgw domain add gateway.my-domain.com
+```
+
+You can then check the status of your gateway domains with:
+
+```
+scwgw domain ls
+```
+
+Once the status is `ready`, all routes on your gateway will be accessible via `gateway.my-domain.com`.
+

--- a/docs/source/domains.md
+++ b/docs/source/domains.md
@@ -1,4 +1,4 @@
-# Custom domain
+# Custom domains
 
 Instead of using the default domain assigned to your gateway, you can add your own custom domains.
 

--- a/docs/source/domains.md
+++ b/docs/source/domains.md
@@ -41,5 +41,4 @@ You can then check the status of your gateway domains with:
 scwgw domain ls
 ```
 
-Once the status is `ready`, all routes on your gateway will be accessible via `gateway.my-domain.com`.
-
+Once the status of the domain is `ready`, all routes on your gateway will be accessible via `gateway.my-domain.com`.


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Added commands to list, add and remove custom domains
- Filled in custom domain docs
- Added integration test for custom domains
- Refactored integration tests to share logic via `GatewayTest` superclass
- Tagged some integration tests (e.g. for domains) as `deployed`, to run only on deployed infra

**_Why do we need this?_**

Users need to be able to manage relative URLs on their domains with their gateways.

**_How have you tested it?_**

Added (long) integration test and run through locally. Note that this test does not run on normal PRs, only on `main`. I have run it through several times from my machine and happy that it _should_ work.

## Checklist

- [x] I have reviewed this myself
- [x] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation