### PR TITLE
feat: add a `profile` option to set the scaleway profile

### DIFF
--- a/cli/cli/client.py
+++ b/cli/cli/client.py
@@ -1,22 +1,21 @@
 import os
 import typing as t
 
+from loguru import logger
 from scaleway import Client
 from scaleway_core.bridge import region
 from scaleway_core.profile.env import ENV_KEY_SCW_PROFILE
-
-from cli.console import console
 
 DEFAULT_API_REGION = region.REGION_FR_PAR
 DEFAULT_PROFILE_NAME = "default"
 
 
-def get_scaleway_client(profile_name: t.Optional[str]) -> Client:
+def get_scaleway_client(profile_name: t.Optional[str] = None) -> Client:
     """Create a Scaleway client."""
     if not profile_name:
         profile_name = os.getenv(ENV_KEY_SCW_PROFILE, DEFAULT_PROFILE_NAME)
     if profile_name != DEFAULT_PROFILE_NAME:
-        console.print(f"Using Scaleway profile: {profile_name}")
+        logger.debug(f"Using Scaleway profile: {profile_name}")
     scw_client = Client.from_config_file_and_env(profile_name=profile_name)
     if not scw_client.default_region:
         scw_client.default_region = DEFAULT_API_REGION

--- a/cli/cli/client.py
+++ b/cli/cli/client.py
@@ -1,12 +1,23 @@
+import os
+import typing as t
+
 from scaleway import Client
 from scaleway_core.bridge import region
+from scaleway_core.profile.env import ENV_KEY_SCW_PROFILE
+
+from cli.console import console
 
 DEFAULT_API_REGION = region.REGION_FR_PAR
+DEFAULT_PROFILE_NAME = "default"
 
 
-def get_scaleway_client() -> Client:
+def get_scaleway_client(profile_name: t.Optional[str]) -> Client:
     """Create a Scaleway client."""
-    scw_client = Client.from_config_file_and_env()
+    if not profile_name:
+        profile_name = os.getenv(ENV_KEY_SCW_PROFILE, DEFAULT_PROFILE_NAME)
+    if profile_name != DEFAULT_PROFILE_NAME:
+        console.print(f"Using Scaleway profile: {profile_name}")
+    scw_client = Client.from_config_file_and_env(profile_name=profile_name)
     if not scw_client.default_region:
         scw_client.default_region = DEFAULT_API_REGION
     return scw_client

--- a/cli/cli/commands/dev.py
+++ b/cli/cli/commands/dev.py
@@ -1,19 +1,22 @@
+import typing as t
+
 import click
 
 from cli import client
+from cli.commands import options
 from cli.infra import InfraManager
 
 
 @click.group()
 def dev():
     """Develop locally"""
-    pass
 
 
 @dev.command()
-def config():
+@options.profile_option
+def config(profile: t.Optional[str]):
     """Set up config for local development"""
-    scw_client = client.get_scaleway_client()
+    scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
     manager.set_up_config(True)
 
@@ -25,11 +28,13 @@ def config():
     default=False,
     help="Don't redeploy the container, just update.",
 )
+@options.profile_option
 def update_containers(
     no_redeploy: bool,
+    profile: t.Optional[str],
 ):
     """Update the containers"""
-    scw_client = client.get_scaleway_client()
+    scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
 
     if no_redeploy:

--- a/cli/cli/commands/domain.py
+++ b/cli/cli/commands/domain.py
@@ -1,36 +1,42 @@
+import typing as t
+
 import click
 
 from cli import client
+from cli.commands import options
 from cli.infra import InfraManager
 
 
 @click.group()
 def domain():
     """Manage gateway domains"""
-    pass
 
 
 @domain.command()
-def ls():
+@options.profile_option
+def ls(profile: t.Optional[str]):  # pylint: disable=invalid-name
     """Print the domains configured on the gateway"""
-    scw_client = client.get_scaleway_client()
+    scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
     manager.print_domains_for_container()
 
 
 @domain.command()
-@click.argument("domain")
-def add(domain):
+@options.profile_option
+@click.argument("domain", type=str)
+def add(domain: str, profile: t.Optional[str]):  # pylint: disable=redefined-outer-name
     """Add a domain to the gateway"""
-    scw_client = client.get_scaleway_client()
+    scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
     manager.add_custom_domain(domain)
 
 
 @domain.command()
-@click.argument("domain")
-def delete(domain):
+@click.argument("domain", type=str)
+def delete(
+    domain: str, profile: t.Optional[str]
+):  # pylint: disable=redefined-outer-name
     """Remove a domain from the gateway"""
-    scw_client = client.get_scaleway_client()
+    scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
     manager.delete_custom_domain(domain)

--- a/cli/cli/commands/options.py
+++ b/cli/cli/commands/options.py
@@ -1,0 +1,15 @@
+import click
+
+from scaleway_core.profile.env import ENV_KEY_SCW_PROFILE
+
+profile_option = click.option(
+    "--profile",
+    "-p",
+    help=f"""The Scaleway profile to use for this command.
+Can also be set with the {ENV_KEY_SCW_PROFILE} environment variable.""",
+    required=False,
+)
+
+not_interactive_option = click.option(
+    "--yes", "-y", is_flag=True, default=False, help="Skip interactive confirmation"
+)

--- a/cli/cli/commands/options.py
+++ b/cli/cli/commands/options.py
@@ -1,5 +1,4 @@
 import click
-
 from scaleway_core.profile.env import ENV_KEY_SCW_PROFILE
 
 profile_option = click.option(


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Added a flag to all commands requiring a scw_client to be able to pass a Scaleway profile

**_Why do we need this?_**

- Make it easier to power users with multiple profiles

**_How have you tested it?_**

- Tested manually with my own profiles

## Checklist

- [x ] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
