### PR TITLE
Raise Kong log level to warn

### DIFF
--- a/gateway/config/kong-admin.conf
+++ b/gateway/config/kong-admin.conf
@@ -5,4 +5,4 @@ admin_access_log = /dev/stdout
 admin_error_log = /dev/stderr
 
 prefix = /var/run/kong
-log_level = info
+log_level = warn

--- a/gateway/config/kong.conf
+++ b/gateway/config/kong.conf
@@ -7,4 +7,4 @@ proxy_access_log = /dev/stdout
 proxy_error_log = /dev/stderr
 
 prefix = /var/run/kong
-log_level = info
+log_level = warn


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Raise log level on Kong and Kong Admin to `warn`

**_Why do we need this?_**

Logging at `notice` and `info` level is very verbose and not useful.

**_How have you tested it?_**

Built and run locally.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details

Avoids logs being swamped as below:

![image](https://github.com/scaleway/serverless-gateway/assets/554768/6e234a65-27ca-4a68-94ea-6efe43b78cc9)
