### PR TITLE
fix: allow deletion when resources are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ If you would like to join in the discussion on how we continue developing the pr
 
 ## :page_with_curl: Contents
 
-- [:computer: Quick-start](#computer-quick-start)
-- [:mortar\_board: Contributing](#mortar_board-contributing)
-- [:mailbox: Reach Us](#mailbox-reach-us)
+- [ Scaleway Serverless Gateway](#-scaleway-serverless-gateway)
+  - [:page\_with\_curl: Contents](#page_with_curl-contents)
+  - [:computer: Quick-start](#computer-quick-start)
+    - [Deploy your gateway](#deploy-your-gateway)
+    - [Add a route](#add-a-route)
+    - [Delete your gateway](#delete-your-gateway)
+  - [:mortar\_board: Contributing](#mortar_board-contributing)
+  - [:mailbox: Reach us](#mailbox-reach-us)
 
 Please see [the docs](https://serverless-gateway.readthedocs.io) for full documentation and features.
 
@@ -41,6 +46,8 @@ To deploy your gateway, you can run:
 ```console
 scwgw infra deploy
 ```
+
+For more information on the deployment process, see the [deployment docs](https://serverless-gateway.readthedocs.io/en/latest/deployment.html).
 
 ### Add a route
 

--- a/cli/cli/commands/infra.py
+++ b/cli/cli/commands/infra.py
@@ -107,7 +107,7 @@ def delete(yes: bool, profile: t.Optional[str] = None):
 
     if not do_delete:
         return
-    
+
     scw_client = client.get_scaleway_client(profile_name=profile)
     manager = InfraManager(scw_client)
 

--- a/cli/cli/commands/infra.py
+++ b/cli/cli/commands/infra.py
@@ -105,13 +105,15 @@ def delete(yes: bool, profile: t.Optional[str] = None):
             "This will delete all the components of your gateway. Are you sure?"
         )
 
-    if do_delete:
-        scw_client = client.get_scaleway_client(profile_name=profile)
-        manager = InfraManager(scw_client)
+    if not do_delete:
+        return
+    
+    scw_client = client.get_scaleway_client(profile_name=profile)
+    manager = InfraManager(scw_client)
 
-        manager.delete_containers()
-        manager.delete_db()
-        manager.delete_namespace()
+    manager.delete_containers()
+    manager.delete_db()
+    manager.delete_namespace()
 
 
 @infra.command()

--- a/cli/cli/infra/manager.py
+++ b/cli/cli/infra/manager.py
@@ -211,7 +211,7 @@ class InfraManager:
             self.rdb.delete_instance(instance_id=instance.id)
             console.print("Kong database deleted")
         except click.Abort:
-            logger.info("Database not found, skipping")
+            logger.debug("Database not found, skipping")
 
     def create_namespace(self):
         """Create the namespace for the gateway."""
@@ -264,7 +264,7 @@ class InfraManager:
             self.containers.delete_namespace(namespace_id=namespace.id)
             console.print("Kong container namespace deleted")
         except click.Abort:
-            logger.info("Namespace not found, skipping")
+            logger.debug("Namespace not found, skipping")
 
     def create_containers(self) -> None:
         """Create containers for Kong and Kong Admin."""
@@ -393,14 +393,14 @@ class InfraManager:
             self.containers.delete_container(container_id=admin_container.id)
             console.print("Kong Admin API container deleted")
         except click.Abort:
-            logger.info("Admin container not found, skipping")
+            logger.debug("Admin container not found, skipping")
 
         try:
             container = self._get_container_or_abort()
             self.containers.delete_container(container_id=container.id)
             console.print("Kong Gateway container deleted")
         except click.Abort:
-            logger.info("Gateway container not found, skipping")
+            logger.debug("Gateway container not found, skipping")
 
     def get_function_endpoint(
         self, namespace_name: str, function_name: str

--- a/cli/cli/infra/secrets.py
+++ b/cli/cli/infra/secrets.py
@@ -37,7 +37,8 @@ def generate_database_password() -> str:
 def create_db_password_secret(api: sdk.SecretV1Alpha1API, db_password: str):
     """Store the password to Secret Manager."""
 
-    delete_db_password_secret(api)
+    # Delete password if already exists
+    delete_db_password_secret_if_exists(api)
 
     logger.debug("Creating secret for database password")
     secret = api.create_secret(
@@ -54,7 +55,7 @@ def create_db_password_secret(api: sdk.SecretV1Alpha1API, db_password: str):
     )
 
 
-def delete_db_password_secret(api: sdk.SecretV1Alpha1API):
+def delete_db_password_secret_if_exists(api: sdk.SecretV1Alpha1API):
     """Delete the password from Secret Manager."""
     try:
         # Delete password if already exists

--- a/docs/source/deployment.md
+++ b/docs/source/deployment.md
@@ -1,0 +1,53 @@
+# Deployment
+
+The Scaleway Gateway can be deployed on your Scaleway account using the `scwgw` utility. As it is an early access product, it is not yet available in the Scaleway CLI. However, the interface is kept as close as possible to the familiar Scaleway CLI interface.
+
+## Prerequisites
+
+- A Scaleway [account](https://console.scaleway.com/)
+- A configured [Scaleway CLI](https://github.com/scaleway/scaleway-cli/blob/master/docs/commands/config.md).
+
+To bootstrap the Scaleway CLI and create a config file you can run the following command:
+
+```console
+scw init
+```
+
+Alternatively, you can configure the using environment variables:
+
+- `SCW_ACCESS_KEY`
+- `SCW_SECRET_KEY`
+- `SCW_DEFAULT_PROJECT_ID`
+- `SCW_DEFAULT_ORGANIZATION_ID`
+
+To configure the Scaleway profile use during the deployment you can use the `SCW_PROFILE` environment variable or the `--profile` flag on the CLI.
+
+## Installation
+
+To deploy the gateway, you can run the following command:
+
+```console
+scwgw infra deploy
+```
+
+This deploy the gateway on your configured Scaleway Project. The deployment will take a few minutes. At the end of the deployment, the CLI will display a summary with the URL of the gateway.
+
+## Configuration
+
+The deployment will generate a configuration file in `$HOME/.config/scw/gateway.yml`. This file contains the configuration of the gateway, and will be used by the CLI to manage the gateway.
+
+The configuration file can also be generated using the following command:
+
+```console
+scwgw infra config
+```
+
+The specific deployment parameters were set by default to work well for most use cases. However, you can change them if you want to customize your deployment by configuring your containers and database with the Scaleway Console.
+
+## Uninstalling
+
+To uninstall the gateway, you can run the following command:
+
+```console
+scwgw infra delete
+```

--- a/docs/source/deployment.md
+++ b/docs/source/deployment.md
@@ -13,7 +13,7 @@ To bootstrap the Scaleway CLI and create a config file you can run the following
 scw init
 ```
 
-Alternatively, you can configure the using environment variables:
+Alternatively, you can configure `scwgw` using the following environment variables:
 
 - `SCW_ACCESS_KEY`
 - `SCW_SECRET_KEY`
@@ -34,7 +34,7 @@ This deploy the gateway on your configured Scaleway Project. The deployment will
 
 ## Configuration
 
-The deployment will generate a configuration file in `$HOME/.config/scw/gateway.yml`. This file contains the configuration of the gateway, and will be used by the CLI to manage the gateway.
+The deployment will generate a configuration file in `$HOME/.config/scw/gateway.yml`. This file contains the configuration of the gateway, and will be used by the CLI to manage it.
 
 The configuration file can also be generated using the following command:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,7 @@ From here you can set up your gateway with:
 
 Once the setup process has finished, you can then manage routes as follows:
 
-.. code-block:: console
+.. code-block:: bash
 
     # Check no routes are configured initially
     scwgw route ls
@@ -60,6 +60,7 @@ Once the setup process has finished, you can then manage routes as follows:
    architecture
    auth
    cors
+   deployment
    development
    domains
    kong


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Adjusted deletion to ignore missing resources

**_Why do we need this?_**

- Currently, it you exit `scw infra deploy` while it's running, you will not be able to safely clean all created resources
- This can happen for instance when using a scoped IAM key and not providing the Cockpit permissions for instance

**_How have you tested it?_**

- Ran locally, deleting the container namespace and was able to delete the database

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
