### PR TITLE
Add doc on IAM permissions

### DIFF
--- a/docs/source/architecture.md
+++ b/docs/source/architecture.md
@@ -13,8 +13,8 @@ The following services are used to run the gateway:
 
 The Kong plugins used are:
 
-- [`jwt`](https://docs.konghq.com/hub/kong-inc/jwt/) - used to add JWT auth to routes (see [the auth docs](https://serverless-gateway.readthedocs.io/en/latest/auth.html))
-- [`cors`](https://docs.konghq.com/hub/kong-inc/jwt/) - used to add CORS headers to responses from routes (see [the CORS docs](https://serverless-gateway.readthedocs.io/en/latest/cors.html))
+- [`jwt`](https://docs.konghq.com/hub/kong-inc/jwt/) - used to add JWT auth to routes (see [](./auth.md))
+- [`cors`](https://docs.konghq.com/hub/kong-inc/jwt/) - used to add CORS headers to responses from routes (see [](./cors.md))
 - [`statsd`](https://docs.konghq.com/hub/kong-inc/statsd/) - used to export metrics from gateway nodes to the Scaleway Cockpit
 
 You can see an architecture diagram with more explanation in our [blog post](https://www.scaleway.com/en/blog/api-gateway-early-access/).

--- a/docs/source/iam.md
+++ b/docs/source/iam.md
@@ -13,7 +13,7 @@ To deploy the gateway using Scaleway IAM, we recommend the following setup:
 5. Create an API key for the application
 6. Use this API key's secret key and access key when deploying your gateway (see below)
 
-Note that by scoping the API key to the new project, you limit the privileges of the key to resources within that project.
+By scoping the API key to the new project, you limit the privileges of the key to resources within that project.
 
 ## Using an API key
 

--- a/docs/source/iam.md
+++ b/docs/source/iam.md
@@ -1,0 +1,6 @@
+# Using Scaleway IAM
+
+If you are managing the gateway using an API token scoped with Scaleway's IAM permissions, your token requires the following permissions:
+
+-
+

--- a/docs/source/iam.md
+++ b/docs/source/iam.md
@@ -13,6 +13,8 @@ To deploy the gateway using Scaleway IAM, we recommend the following setup:
 5. Create an API key for the application
 6. Use this API key's secret key and access key when deploying your gateway (see below)
 
+Note that by scoping the API key to the new project, you limit the privileges of the key to resources within that project.
+
 ## Using an API key
 
 The easiest ways to use an API key are via:
@@ -20,4 +22,4 @@ The easiest ways to use an API key are via:
 1. A profile in your Scaleway CLI config file (either set as the default, or using the `--profile` argument for the gateway CLI)
 2. Environment variables, setting `SCW_ACCESS_KEY` and `SCW_SECRET_KEY` in the environment where you run `scwgw`
 
-See the [deployment docs](https://serverless-gateway.readthedocs.io/en/latest/deployment.html) for more information on how to use both approaches to configure your Scaleway CLI.
+See [](./deployment.md) for more information on how to use both approaches to configure your Scaleway CLI.

--- a/docs/source/iam.md
+++ b/docs/source/iam.md
@@ -1,6 +1,23 @@
 # Using Scaleway IAM
 
-If you are managing the gateway using an API token scoped with Scaleway's IAM permissions, your token requires the following permissions:
+To deploy the gateway using Scaleway IAM, we recommend the following setup:
 
--
+1. Create a new Scaleway project
+2. Create an IAM application scoped to this project
+3. Add a policy with this application as principal
+4. Add the following rules to the policy:
+    - Serverless -> `ContainersFullAccess`
+    - Managed services -> `ObservabilityFullAccess`
+    - Managed databases -> `RelationalDatabasesFullAccess`
+    - Security and identity -> `SecretManagerFullAccess`
+5. Create an API key for the application
+6. Use this API key's secret key and access key when deploying your gateway (see below)
 
+## Using an API key
+
+The easiest ways to use an API key are via:
+
+1. A profile in your Scaleway CLI config file (either set as the default, or using the `--profile` argument for the gateway CLI)
+2. Environment variables, setting `SCW_ACCESS_KEY` and `SCW_SECRET_KEY` in the environment where you run `scwgw`
+
+See the [deployment docs](https://serverless-gateway.readthedocs.io/en/latest/deployment.html) for more information on how to use both approaches to configure your Scaleway CLI.

--- a/docs/source/iam.md
+++ b/docs/source/iam.md
@@ -1,4 +1,4 @@
-# Using Scaleway IAM
+# IAM
 
 To deploy the gateway using Scaleway IAM, we recommend the following setup:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,6 +64,7 @@ Once the setup process has finished, you can then manage routes as follows:
    deployment
    development
    domains
+   iam
    kong
    observability
    serverless


### PR DESCRIPTION
## Summary

**_What's changed?_**

Document necessary IAM roles for API tokens used to provision a gateway.

**_Why do we need this?_**

Without this doc, the process is trial-and-error (and the error message doesn't specify which permissions are missing).

**_How have you tested it?_**

Run through deploy and deletion on my personal account with an IAM-based API token.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [x] I have updated the relevant documentation