### PR TITLE
Add retry on deploy

### DIFF
--- a/gateway/scripts/run-grafana-agent.sh
+++ b/gateway/scripts/run-grafana-agent.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# We sleep here as we need to give the gateway time to start
+sleep 20
+
 /bin/grafana-agent                      \
     --config.expand-env                 \
     --config.file=/etc/agent/agent.yaml

--- a/gateway/scripts/run-grafana-agent.sh
+++ b/gateway/scripts/run-grafana-agent.sh
@@ -3,7 +3,7 @@
 set -e
 
 # We sleep here as we need to give the gateway time to start
-sleep 20
+sleep 30
 
 /bin/grafana-agent                      \
     --config.expand-env                 \

--- a/gateway/scripts/startup.sh
+++ b/gateway/scripts/startup.sh
@@ -22,9 +22,8 @@ else
 
     # Reference: https://docs.docker.com/config/containers/multi-service_container/
     # We need to retry here to give the admin container time to apply database migrations
-    for i in 1 2 3 4 5;
-    do
-        kong start -v -c /kong-conf/kong.conf && break || sleep 30;
+    for i in {1..30}; do
+        kong start -v -c /kong-conf/kong.conf && break || sleep 15;
     done
 fi
 

--- a/gateway/scripts/startup.sh
+++ b/gateway/scripts/startup.sh
@@ -13,15 +13,18 @@ if [ ! -z "$IS_ADMIN_CONTAINER" ]; then
     echo "Starting Kong admin"
     kong start -v -c /kong-conf/kong-admin.conf
 else
-    echo "Starting Kong"
-    # Reference: https://docs.docker.com/config/containers/multi-service_container/
-    kong start -v -c /kong-conf/kong.conf &
-
     if [ ! -z "$FORWARD_METRICS" ]; then
-        echo "Starting Grafana Agent"
-        /scripts/run-grafana-agent.sh
+        echo "Starting Grafana Agent in background"
+        /scripts/run-grafana-agent.sh &
     fi
 
-    fg %1
+    echo "Starting Kong"
+
+    # Reference: https://docs.docker.com/config/containers/multi-service_container/
+    # We need to retry here to give the admin container time to apply database migrations
+    for i in 1 2 3 4 5;
+    do
+        kong start -v -c /kong-conf/kong.conf && break || sleep 15;
+    done
 fi
 

--- a/gateway/scripts/startup.sh
+++ b/gateway/scripts/startup.sh
@@ -24,7 +24,7 @@ else
     # We need to retry here to give the admin container time to apply database migrations
     for i in 1 2 3 4 5;
     do
-        kong start -v -c /kong-conf/kong.conf && break || sleep 15;
+        kong start -v -c /kong-conf/kong.conf && break || sleep 30;
     done
 fi
 


### PR DESCRIPTION
## Summary

**_What's changed?_**

Add retry when starting gateway container.

**_Why do we need this?_**

Sometimes the gateway container will fail if the admin container hasn't had time to run the db migrations.

**_How have you tested it?_**

Run integration tests locally and on the branch. Ran with fresh db with no migrations and checked retry happens.

## Checklist

- [x] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation