### PR TITLE
fix: missing changelog when building package

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,1 +1,0 @@
-<!-- This CHANGELOG will be overwritten by the top-level CHANGELOG when publishing to PyPI>

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -40,17 +40,17 @@ sed -i '/<!-- no toc -->/,/<!-- no toc -->/d' README.md
 
 poetry build
 
-# Restore the README abd CHANGELOG if git is installed
-if command -v git &> /dev/null
-then
-    git checkout -- README.md
-    git checkout -- CHANGELOG.md
-fi
-
 if [ "$DRY_RUN" = true ]; then
     poetry publish -r testpypi
 else
     poetry publish
+fi
+
+# Restore the README if git is installed
+# This is for convenience when developing
+if command -v git &> /dev/null
+then
+    git checkout -- README.md
 fi
 
 popd >> /dev/null


### PR DESCRIPTION
## Summary

**_What's changed?_**

- Changed the pypi/build.sh script

**_Why do we need this?_**

Build pipeline is failing when attempting to git restore an unknow file to git

**_How have you tested it?_**

Ran locally :/

## Checklist

- [ ] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation

## Details
